### PR TITLE
Fix type of variable to hold vo_paramNext() return value

### DIFF
--- a/voapps/task/pkgMain.c
+++ b/voapps/task/pkgMain.c
@@ -51,8 +51,8 @@ static struct option long_opts[] = {
  */
 int main (int argc, char *argv[])
 {
-    char **pargv, optval[SZ_FNAME], ch;
-    int    pos = 0;
+    char **pargv, optval[SZ_FNAME];
+    int    pos = 0, ch;
 
 
     /* Process arguments.

--- a/voapps/voatlas.c
+++ b/voapps/voatlas.c
@@ -123,10 +123,10 @@ static void Tests (char *input);
 int 
 voatlas (int argc, char **argv, size_t *reslen, void **result)
 {
-    char **pargv, optval[SZ_FNAME], ch;
+    char **pargv, optval[SZ_FNAME];
     char  *iname = NULL, *oname = NULL, *dlname = NULL;
     char   tmp[SZ_FNAME], buf[SZ_FNAME];
-    int    i=1, status = OK, apos = 0, samp = -1, naxis = 512;
+    int    i=1, status = OK, apos = 0, samp = -1, naxis = 512, ch;
 
 
     /*  Initialize.

--- a/voapps/vosamp.c
+++ b/voapps/vosamp.c
@@ -253,8 +253,8 @@ static void Tests (char *input);
 int
 vosamp (int argc, char **argv, size_t *reslen, void **result)
 {
-    char **pargv, optval[SZ_FNAME], ch, *env_proxy = NULL;
-    int	   i, pos = 0, len = 0;
+    char **pargv, optval[SZ_FNAME], *env_proxy = NULL;
+    int	   i, pos = 0, len = 0, ch;
     time_t expiry;
 
 

--- a/voapps/vosession.c
+++ b/voapps/vosession.c
@@ -222,8 +222,8 @@ static void  sess_printClients (void);
 int
 main (int argc, char **argv)
 {
-    char  **pargv, optval[SZ_FNAME], ch;
-    int	    i, rc, pos = 0;
+    char  **pargv, optval[SZ_FNAME];
+    int	    i, rc, pos = 0, ch;
 
 
 

--- a/voapps/vosloanspec.c
+++ b/voapps/vosloanspec.c
@@ -180,9 +180,9 @@ extern char *vo_urlEncode (char *target);
 int
 vosloanspec (int argc, char **argv, size_t *reslen, void **result)
 {
-    int    apos, argnum = 0, status = OK;
+    int    apos, argnum = 0, status = OK, ch;
     FILE  *fd = (FILE *) NULL;
-    char **pargv, optval[SZ_FNAME], ch, *urlList = NULL;;
+    char **pargv, optval[SZ_FNAME], *urlList = NULL;;
     char  *tmp = vot_mktemp ("vosloan");
 
 

--- a/voapps/votcat.c
+++ b/voapps/votcat.c
@@ -60,9 +60,9 @@ int
 votcat (int argc, char **argv, size_t *reslen, void **result)
 {
     char **pargv, optval[SZ_FNAME];
-    char  *oname = (char *) NULL, ch;
+    char  *oname = (char *) NULL;
     char  *infile[MAX_FILES];
-    int   i, verbose = 0, indent = 1, pos = 0;
+    int   i, verbose = 0, indent = 1, pos = 0, ch;
 
 
     if (argc < 3) {

--- a/voapps/votcnv.c
+++ b/voapps/votcnv.c
@@ -70,9 +70,9 @@ extern int vot_atoi (char *v);
 int
 votcnv (int argc, char **argv, size_t *reslen, void **result)
 {
-    int     status = OK, pos = 0;
+    int     status = OK, pos = 0, ch;
     char   *iname = NULL, *name = NULL, *oname = NULL, format[SZ_FORMAT];
-    char  **pargv, ch, optval[SZ_FNAME];
+    char  **pargv, optval[SZ_FNAME];
 
 
     /*  Parse the argument list.

--- a/voapps/votget.c
+++ b/voapps/votget.c
@@ -197,8 +197,8 @@ int
 votget (int argc, char **argv, size_t *reslen, void **result)
 {
     char **pargv, optval[SZ_FNAME];
-    char  *iname = NULL, ch;
-    int    samp = 0, pos = 0, stat = OK;
+    char  *iname = NULL;
+    int    samp = 0, pos = 0, stat = OK, ch;
 
 
     /*  Initialize. 


### PR DESCRIPTION
`vo_paramNext()` returns an `int`, and specifically returns a negative value
if there are arguments left after processing the options.

Depending on the signedness of `char`, this may be converted to a positive
value if the return value is converted to a `char`. This happens f.e. on ARM
processors, where the char is `unsigned char` by default. Since the option
parsing is stopped when this is `<=0`, additional (non-option) arguments lead
to an errornous processing.

The correct type to hold the return value is `int`, and this was already set
in some VO applications (f.e. `votjoin`). This patch changes this for the
remaining apps.

This fixes the read problem of VOTables on arm processors.

This was already proposed as pull request
[iraf/iraf-v216#112](https://iraf-community.github.io/iraf-v216/issues/112)
but got ignored at that time.